### PR TITLE
Remove Direct Configuration section from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,20 +70,6 @@ Available systems:
 - `aarch64-darwin` (Apple Silicon macOS)
 - `x86_64-linux` (Linux x86_64)
 
-### Direct Configuration (Advanced)
-
-For advanced use cases, you can use the underlying nvf configuration directly:
-
-```nix
-(nvf-config.lib.neovimConfiguration {
-  pkgs = nixpkgs.legacyPackages.<system>;
-  modules = [./your-modules];
-  extraSpecialArgs = { mylib = import ./lib { inherit (nixpkgs) lib; }; };
-})
-```
-
-Note: The `nvf-config` modules use a local `scanPaths` utility for automatic module discovery, so if you're creating custom modules, you may want to use explicit imports instead.
-
 
 ## Development
 


### PR DESCRIPTION
Removed advanced configuration section from README.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes the advanced "Direct Configuration" section from README and cleans up formatting.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cb657fc39a02a95f0848941b99c838ea245318e4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->